### PR TITLE
fix type miscasting

### DIFF
--- a/Sources/CommonCurves/Secp256k1.swift
+++ b/Sources/CommonCurves/Secp256k1.swift
@@ -40,7 +40,7 @@ public struct Secp256k1: EllipticCurveOverFiniteField {
 
     public static var Generator = Secp256k1(withCoordinates: Parameters.G)
     public static var Order: UInt256 = Parameters.N
-    public static var InverseOrder: (UInt256, UInt256)? = Parameters.InverseN
+    public static var InverseOrder: (high: UInt256, low: UInt256)? = Parameters.InverseN
 
     public static var a = FFInt(Parameters.a)
     public static var b = FFInt(Parameters.b)

--- a/Sources/FiniteField/FiniteFieldInteger+Default.swift
+++ b/Sources/FiniteField/FiniteFieldInteger+Default.swift
@@ -104,8 +104,12 @@ extension FiniteFieldInteger {
 
     public static func *(lhs: Self, rhs: Self) -> Self {
         let (high, low) = lhs.value.multipliedFullWidth(by: rhs.value)
-        let inv = Self.InverseCharacteristic ?? (0, 0)
-        let (_, remain) = Self.Characteristic.dividingFullWidth((high, low), withPrecomputedInverse: inv)
+        let remain: Element
+        if let inv = Self.InverseCharacteristic {
+            (_, remain) = Self.Characteristic.dividingFullWidth((high, low), withPrecomputedInverse: inv)
+        } else {
+            (_, remain) = Self.Characteristic.dividingFullWidth((high, low))
+        }
         return Self(withValue: remain)
     }
 

--- a/Tests/ECDSATests.swift
+++ b/Tests/ECDSATests.swift
@@ -34,6 +34,10 @@ class ECDSATests: XCTestCase {
 
     func testInit() {
         let e = ECDSA<MyECFF>()
+        XCTAssertNil(FFInt7.InverseOrder)
+        XCTAssertNil(FFInt7.InverseCharacteristic)
+        XCTAssertNil(MyECFF.InverseOrder)
+        XCTAssertNil(MyECFF.InverseCharacteristic)
         XCTAssertNotNil(e)
     }
 

--- a/Tests/PerformanceTests.swift
+++ b/Tests/PerformanceTests.swift
@@ -39,7 +39,7 @@ class PerformanceTests: XCTestCase {
             let _ = privkey * Secp256k1.Generator
         }
     }
-/*
+
     func testMultiplicationPerf32() {
         self.measure {
             let privkey = UInt256(1) << 32
@@ -53,7 +53,7 @@ class PerformanceTests: XCTestCase {
             let _ = privkey * Secp256k1.Generator
         }
     }
- */
+
     // make sure the building process does not slow down UInt256
     func testUInt256Multiplication() {
         self.measure {

--- a/Tests/Secp256k1Tests.swift
+++ b/Tests/Secp256k1Tests.swift
@@ -8,6 +8,8 @@ class Secp256k1Tests: XCTestCase {
     func testInit() {
         XCTAssertNotNil(Secp256k1())
         XCTAssertNotNil(Secp256k1.Generator)
+        XCTAssertNotNil(Secp256k1.InverseOrder)
+        XCTAssertNotNil(Secp256k1.InverseCharacteristic)
     }
 
     func testPubPoint0() {


### PR DESCRIPTION
swift compiler does not consider these two the same: (Type, Type) and (high: Type, low: Type)